### PR TITLE
fix: Validate SettledReceived state before rolling back the signed channel state

### DIFF
--- a/dlc-manager/src/channel/signed_channel.rs
+++ b/dlc-manager/src/channel/signed_channel.rs
@@ -348,6 +348,9 @@ impl SignedChannel {
     pub fn get_contract_id(&self) -> Option<ContractId> {
         self.state.get_contract_id()
     }
+
+    /// Returns the reference id associated with the signed channel.
+    pub fn get_reference_id(&self) -> Option<ReferenceId> { self.state.get_reference_id() }
 }
 
 impl SignedChannelState {
@@ -365,6 +368,23 @@ impl SignedChannelState {
             SignedChannelState::RenewFinalized { contract_id, .. } => Some(*contract_id),
             SignedChannelState::Closing { contract_id, .. } => Some(*contract_id),
             _ => None,
+        }
+    }
+
+    fn get_reference_id(&self) -> Option<ReferenceId> {
+        match self {
+            SignedChannelState::Established { reference_id, ..} => *reference_id,
+            SignedChannelState::SettledOffered { reference_id, ..} => *reference_id,
+            SignedChannelState::SettledReceived { reference_id, ..} => *reference_id,
+            SignedChannelState::SettledAccepted { reference_id, ..} => *reference_id,
+            SignedChannelState::SettledConfirmed { reference_id, ..} => *reference_id,
+            SignedChannelState::Settled { reference_id, ..} => *reference_id,
+            SignedChannelState::RenewOffered { reference_id, ..} => *reference_id,
+            SignedChannelState::RenewAccepted { reference_id, ..} => *reference_id,
+            SignedChannelState::RenewConfirmed { reference_id, ..} => *reference_id,
+            SignedChannelState::RenewFinalized { reference_id, ..} => *reference_id,
+            SignedChannelState::Closing { reference_id, ..} => *reference_id,
+            SignedChannelState::CollaborativeCloseOffered { reference_id, ..} => *reference_id,
         }
     }
 }

--- a/dlc-manager/src/channel_updater.rs
+++ b/dlc-manager/src/channel_updater.rs
@@ -1381,17 +1381,18 @@ pub fn settle_channel_on_finalize<C: Signing>(
 /// Creates a [`Reject`] message and rolls back the state of the channel. Expects
 /// the channel to be in [`SignedChannelState::SettledOffered`] state.
 pub fn reject_settle_offer(signed_channel: &mut SignedChannel) -> Result<Reject, Error> {
+    get_signed_channel_state!(signed_channel, SettledReceived, reference_id)?;
+
     signed_channel.state = signed_channel
         .roll_back_state
         .take()
         .expect("to have a rollback state");
 
-    let reference_id = get_signed_channel_state!(signed_channel, SettledReceived, reference_id)?;
-
+    let reference_id = signed_channel.get_reference_id();
     Ok(Reject {
         channel_id: signed_channel.channel_id,
         timestamp: get_unix_time_now(),
-        reference_id: *reference_id
+        reference_id
     })
 }
 


### PR DESCRIPTION
That has been a regression introduced by [^1]. By loading the signed channel state of state `SettledReceived` we implicitly validate that the signed channel is in a correct state. Moving that macro after the rollback will always fail, because the channel got rolled back either to `Established` or `Settled`.

[^1]: https://github.com/get10101/rust-dlc/commit/d7830193ad195551743d4808c8c9cfde0b4ffa2d.