### PR TITLE
fix: Maintain reference id on signed channel instead of the signed channel state for compatibility reasons.

### DIFF
--- a/dlc-manager/src/channel/mod.rs
+++ b/dlc-manager/src/channel/mod.rs
@@ -5,7 +5,6 @@ use dlc_messages::channel::{AcceptChannel, SignChannel};
 use secp256k1_zkp::PublicKey;
 
 use crate::{ContractId, DlcChannelId, ReferenceId};
-use crate::channel::signed_channel::SignedChannelState;
 
 use self::{
     accepted_channel::AcceptedChannel, offered_channel::OfferedChannel,
@@ -98,20 +97,7 @@ impl Channel {
         match self {
             Channel::Offered(o) => o.reference_id,
             Channel::Accepted(a) => a.reference_id,
-            Channel::Signed(s) => match s.state {
-                SignedChannelState::Established { reference_id, .. } => reference_id,
-                SignedChannelState::SettledOffered { reference_id, .. } => reference_id,
-                SignedChannelState::SettledReceived { reference_id, .. } => reference_id,
-                SignedChannelState::SettledAccepted { reference_id, .. } => reference_id,
-                SignedChannelState::SettledConfirmed { reference_id, .. } => reference_id,
-                SignedChannelState::Settled { reference_id, .. } => reference_id,
-                SignedChannelState::RenewOffered { reference_id, .. } => reference_id,
-                SignedChannelState::RenewAccepted { reference_id, .. } => reference_id,
-                SignedChannelState::RenewConfirmed { reference_id, .. } => reference_id,
-                SignedChannelState::RenewFinalized { reference_id, .. } => reference_id,
-                SignedChannelState::Closing { reference_id, .. } => reference_id,
-                SignedChannelState::CollaborativeCloseOffered { reference_id, .. } => reference_id,
-            },
+            Channel::Signed(s) => s.reference_id,
             Channel::FailedAccept(f) => f.reference_id,
             Channel::FailedSign(f) => f.reference_id,
             Channel::Closing(c) => c.reference_id,

--- a/dlc-manager/src/channel/ser.rs
+++ b/dlc-manager/src/channel/ser.rs
@@ -47,23 +47,24 @@ impl_dlc_writeable!(SignedChannel, {
     (own_per_update_seed, writeable),
     (counter_party_commitment_secrets, writeable),
     (fee_rate_per_vb, writeable),
-    (sub_channel_id, option)
+    (sub_channel_id, option),
+    (reference_id, option)
 });
 
 impl_dlc_writeable_enum!(
     SignedChannelState,;
-    (0, Established, {(signed_contract_id, writeable), (own_buffer_adaptor_signature, {cb_writeable, write_ecdsa_adaptor_signature, read_ecdsa_adaptor_signature}), (counter_buffer_adaptor_signature, {cb_writeable, write_ecdsa_adaptor_signature, read_ecdsa_adaptor_signature}), (buffer_transaction, writeable), (is_offer, writeable), (total_collateral, writeable), (reference_id, option)}),
-    (1, SettledOffered, {(counter_payout, writeable), (next_per_update_point, writeable), (timeout, writeable), (reference_id, option)}),
-    (2, SettledReceived, {(own_payout, writeable), (counter_next_per_update_point, writeable), (counter_payout, writeable), (reference_id, option)}),
-    (3, SettledAccepted, {(counter_next_per_update_point, writeable), (own_next_per_update_point, writeable), (settle_tx, writeable), (own_settle_adaptor_signature, {cb_writeable, write_ecdsa_adaptor_signature, read_ecdsa_adaptor_signature}), (timeout, writeable), (own_payout, writeable), (counter_payout, writeable), (reference_id, option)}),
-    (4, SettledConfirmed, {(settle_tx, writeable), (counter_settle_adaptor_signature, {cb_writeable, write_ecdsa_adaptor_signature, read_ecdsa_adaptor_signature}), (own_settle_adaptor_signature, {cb_writeable, write_ecdsa_adaptor_signature, read_ecdsa_adaptor_signature}), (counter_next_per_update_point, writeable), (own_next_per_update_point, writeable), (timeout, writeable), (own_payout, writeable), (counter_payout, writeable), (reference_id, option) }),
-    (5, Settled, {(settle_tx, writeable), (counter_settle_adaptor_signature, {cb_writeable, write_ecdsa_adaptor_signature, read_ecdsa_adaptor_signature}), (own_settle_adaptor_signature, {cb_writeable, write_ecdsa_adaptor_signature, read_ecdsa_adaptor_signature}), (own_payout, writeable), (counter_payout, writeable), (reference_id, option)}),
-    (6, RenewOffered, {(offered_contract_id, writeable), (counter_payout, writeable), (is_offer, writeable), (offer_next_per_update_point, writeable), (timeout, writeable), (reference_id, option)}),
-    (7, RenewAccepted, {(contract_id, writeable), (offer_per_update_point, writeable), (accept_per_update_point, writeable), (buffer_transaction, writeable), (buffer_script_pubkey, writeable), (timeout, writeable), (own_payout, writeable), (reference_id, option)}),
-    (8, RenewConfirmed, {(contract_id, writeable), (offer_per_update_point, writeable), (accept_per_update_point, writeable), (buffer_transaction, writeable), (buffer_script_pubkey, writeable), (offer_buffer_adaptor_signature, {cb_writeable, write_ecdsa_adaptor_signature, read_ecdsa_adaptor_signature}), (timeout, writeable), (own_payout, writeable), (total_collateral, writeable), (reference_id, option)}),
-    (10, RenewFinalized, {(contract_id, writeable), (prev_offer_per_update_point, writeable), (buffer_transaction, writeable), (buffer_script_pubkey, writeable), (offer_buffer_adaptor_signature, {cb_writeable, write_ecdsa_adaptor_signature, read_ecdsa_adaptor_signature}), (accept_buffer_adaptor_signature, {cb_writeable, write_ecdsa_adaptor_signature, read_ecdsa_adaptor_signature}), (timeout, writeable), (own_payout, writeable), (total_collateral, writeable), (reference_id, option)}),
-    (9, Closing, {(buffer_transaction, writeable), (contract_id, writeable), (is_initiator, writeable), (reference_id, option)}),
-    (11, CollaborativeCloseOffered, { (counter_payout, writeable), (offer_signature, writeable), (close_tx, writeable), (timeout, writeable), (is_offer, writeable), (reference_id, option) })
+    (0, Established, {(signed_contract_id, writeable), (own_buffer_adaptor_signature, {cb_writeable, write_ecdsa_adaptor_signature, read_ecdsa_adaptor_signature}), (counter_buffer_adaptor_signature, {cb_writeable, write_ecdsa_adaptor_signature, read_ecdsa_adaptor_signature}), (buffer_transaction, writeable), (is_offer, writeable), (total_collateral, writeable)}),
+    (1, SettledOffered, {(counter_payout, writeable), (next_per_update_point, writeable), (timeout, writeable)}),
+    (2, SettledReceived, {(own_payout, writeable), (counter_next_per_update_point, writeable), (counter_payout, writeable)}),
+    (3, SettledAccepted, {(counter_next_per_update_point, writeable), (own_next_per_update_point, writeable), (settle_tx, writeable), (own_settle_adaptor_signature, {cb_writeable, write_ecdsa_adaptor_signature, read_ecdsa_adaptor_signature}), (timeout, writeable), (own_payout, writeable), (counter_payout, writeable)}),
+    (4, SettledConfirmed, {(settle_tx, writeable), (counter_settle_adaptor_signature, {cb_writeable, write_ecdsa_adaptor_signature, read_ecdsa_adaptor_signature}), (own_settle_adaptor_signature, {cb_writeable, write_ecdsa_adaptor_signature, read_ecdsa_adaptor_signature}), (counter_next_per_update_point, writeable), (own_next_per_update_point, writeable), (timeout, writeable), (own_payout, writeable), (counter_payout, writeable) }),
+    (5, Settled, {(settle_tx, writeable), (counter_settle_adaptor_signature, {cb_writeable, write_ecdsa_adaptor_signature, read_ecdsa_adaptor_signature}), (own_settle_adaptor_signature, {cb_writeable, write_ecdsa_adaptor_signature, read_ecdsa_adaptor_signature}), (own_payout, writeable), (counter_payout, writeable)}),
+    (6, RenewOffered, {(offered_contract_id, writeable), (counter_payout, writeable), (is_offer, writeable), (offer_next_per_update_point, writeable), (timeout, writeable)}),
+    (7, RenewAccepted, {(contract_id, writeable), (offer_per_update_point, writeable), (accept_per_update_point, writeable), (buffer_transaction, writeable), (buffer_script_pubkey, writeable), (timeout, writeable), (own_payout, writeable)}),
+    (8, RenewConfirmed, {(contract_id, writeable), (offer_per_update_point, writeable), (accept_per_update_point, writeable), (buffer_transaction, writeable), (buffer_script_pubkey, writeable), (offer_buffer_adaptor_signature, {cb_writeable, write_ecdsa_adaptor_signature, read_ecdsa_adaptor_signature}), (timeout, writeable), (own_payout, writeable), (total_collateral, writeable)}),
+    (10, RenewFinalized, {(contract_id, writeable), (prev_offer_per_update_point, writeable), (buffer_transaction, writeable), (buffer_script_pubkey, writeable), (offer_buffer_adaptor_signature, {cb_writeable, write_ecdsa_adaptor_signature, read_ecdsa_adaptor_signature}), (accept_buffer_adaptor_signature, {cb_writeable, write_ecdsa_adaptor_signature, read_ecdsa_adaptor_signature}), (timeout, writeable), (own_payout, writeable), (total_collateral, writeable)}),
+    (9, Closing, {(buffer_transaction, writeable), (contract_id, writeable), (is_initiator, writeable)}),
+    (11, CollaborativeCloseOffered, { (counter_payout, writeable), (offer_signature, writeable), (close_tx, writeable), (timeout, writeable), (is_offer, writeable) })
     ;;
 );
 

--- a/dlc-manager/src/channel/signed_channel.rs
+++ b/dlc-manager/src/channel/signed_channel.rs
@@ -109,8 +109,6 @@ typed_enum!(
             is_offer: bool,
             /// The total amount of collateral in the channel
             total_collateral: u64,
-            /// The reference id set by the api user.
-            reference_id: Option<ReferenceId>,
         },
         /// A [`SignedChannel`] is in `SettledOffered` state when the local party
         /// has sent a [`dlc_messages::channel::SettleOffer`] message.
@@ -123,8 +121,6 @@ typed_enum!(
             /// The UNIX epoch at which the counter party will be considered
             /// unresponsive and the channel will be forced closed.
             timeout: u64,
-            /// The reference id set by the api user.
-            reference_id: Option<ReferenceId>,
         },
         /// A [`SignedChannel`] is in `SettledReceived` state when the local party
         /// has received a [`dlc_messages::channel::SettleOffer`] message.
@@ -136,8 +132,6 @@ typed_enum!(
             /// The per update point to be used by the counter party for the setup
             /// of the next channel state.
             counter_next_per_update_point: PublicKey,
-            /// The reference id set by the api user.
-            reference_id: Option<ReferenceId>,
         },
         /// A [`SignedChannel`] is in `SettledAccepted` state when the local party
         /// has sent a [`dlc_messages::channel::SettleAccept`] message.
@@ -160,8 +154,6 @@ typed_enum!(
             own_payout: u64,
             /// The payout that was proposed to the counter party.
             counter_payout: u64,
-            /// The reference id set by the api user.
-            reference_id: Option<ReferenceId>,
         },
         /// A [`SignedChannel`] is in `SettledConfirmed` state when the local party
         /// has sent a [`dlc_messages::channel::SettleConfirm`] message.
@@ -187,8 +179,6 @@ typed_enum!(
             own_payout: u64,
             /// The payout that was proposed to the counter party.
             counter_payout: u64,
-            /// The reference id set by the api user.
-            reference_id: Option<ReferenceId>,
         },
         /// A [`SignedChannel`] is in `Settled` state when the local party
         /// has all the necessary information to close the channel with the last
@@ -206,8 +196,6 @@ typed_enum!(
             own_payout: u64,
             /// The amount the counter party holds in the channel.
             counter_payout: u64,
-            /// The reference id set by the api user.
-            reference_id: Option<ReferenceId>,
         },
         /// A [`SignedChannel`] is in `RenewOffered` state when the local party
         /// has sent or received a [`dlc_messages::channel::RenewOffer`] message.
@@ -224,8 +212,6 @@ typed_enum!(
             /// The UNIX epoch at which the counter party will be considered
             /// unresponsive and the channel will be forced closed.
             timeout: u64,
-            /// The reference id set by the api user.
-            reference_id: Option<ReferenceId>,
         },
         /// A [`SignedChannel`] is in `RenewAccepted` state when the local party
         /// has sent a [`dlc_messages::channel::RenewAccept`] message.
@@ -247,8 +233,6 @@ typed_enum!(
             timeout: u64,
             /// The payout to the local party attributed for closing the previous state.
             own_payout: u64,
-            /// The reference id set by the api user.
-            reference_id: Option<ReferenceId>,
         },
         /// A [`SignedChannel`] is in `RenewConfirmed` state when the local party
         /// has sent a [`dlc_messages::channel::RenewConfirm`] message.
@@ -275,8 +259,6 @@ typed_enum!(
             own_payout: u64,
             /// The total amount of collateral in the channel.
             total_collateral: u64,
-            /// The reference id set by the api user.
-            reference_id: Option<ReferenceId>,
         },
         /// Finalize the renewal of the contract within a DLC channel.
         RenewFinalized {
@@ -302,8 +284,6 @@ typed_enum!(
             own_payout: u64,
             /// The total amount of collateral in the channel.
             total_collateral: u64,
-            /// The reference id set by the api user.
-            reference_id: Option<ReferenceId>,
         },
         /// A [`SignedChannel`] is in `Closing` state when the local party
         /// has broadcast a buffer transaction and is waiting to finalize the
@@ -316,8 +296,6 @@ typed_enum!(
             contract_id: ContractId,
             /// Whether the local party initiated the closing of the channel.
             is_initiator: bool,
-            /// The reference id set by the api user.
-            reference_id: Option<ReferenceId>,
         },
         /// A [`SignedChannel`] is in `CollaborativeCloseOffered` state when the local party
         /// has sent a [`dlc_messages::channel::CollaborativeCloseOffer`] message.
@@ -333,8 +311,6 @@ typed_enum!(
             timeout: u64,
             /// Indicates whether the local party offered the collaborative close or not.
             is_offer: bool,
-            /// The reference id set by the api user.
-            reference_id: Option<ReferenceId>,
         },
     },
     /// Enum automatically generated associating a number to each signed channel
@@ -412,6 +388,8 @@ pub struct SignedChannel {
     pub fee_rate_per_vb: u64,
     /// Whether this channel is embedded within a Lightning Network channel.
     pub sub_channel_id: Option<ChannelId>,
+    /// The reference id set by the api user.
+    pub reference_id: Option<ReferenceId>,
 }
 
 impl SignedChannel {


### PR DESCRIPTION
This would otherwise be a breaking change as new attributes can only be added trailing, without running into a DecodeError::ShortRead`