### PR TITLE
feat: Add closing txid to channel

### DIFF
--- a/dlc-manager/src/channel/mod.rs
+++ b/dlc-manager/src/channel/mod.rs
@@ -178,6 +178,8 @@ pub struct ClosedChannel {
     pub channel_id: DlcChannelId,
     /// The reference id set by the api user.
     pub reference_id: Option<ReferenceId>,
+    /// The txid that closed that channel
+    pub closing_txid: Txid,
 }
 
 #[derive(Clone)]

--- a/dlc-manager/src/channel/ser.rs
+++ b/dlc-manager/src/channel/ser.rs
@@ -81,5 +81,5 @@ impl_dlc_writeable!(ClosingChannel, {
     (is_closer, writeable),
     (reference_id, option)
 });
-impl_dlc_writeable!(ClosedChannel, {(channel_id, writeable), (counter_party, writeable), (temporary_channel_id, writeable), (reference_id, option)});
+impl_dlc_writeable!(ClosedChannel, {(channel_id, writeable), (counter_party, writeable), (temporary_channel_id, writeable), (reference_id, option), (closing_txid, writeable)});
 impl_dlc_writeable!(ClosedPunishedChannel, {(channel_id, writeable), (counter_party, writeable), (temporary_channel_id, writeable), (punish_txid, writeable), (reference_id, option)});

--- a/dlc-manager/src/channel_updater.rs
+++ b/dlc-manager/src/channel_updater.rs
@@ -2362,7 +2362,8 @@ where
         counter_party: signed_channel.counter_party,
         temporary_channel_id: signed_channel.temporary_channel_id,
         channel_id: signed_channel.channel_id,
-        reference_id: signed_channel.reference_id
+        reference_id: signed_channel.reference_id,
+        closing_txid: close_tx.txid()
     });
     Ok((close_tx, channel))
 }
@@ -2694,7 +2695,8 @@ where
         counter_party: signed_channel.counter_party,
         temporary_channel_id: signed_channel.temporary_channel_id,
         channel_id: signed_channel.channel_id,
-        reference_id: signed_channel.reference_id
+        reference_id: signed_channel.reference_id,
+        closing_txid: cet.txid()
     };
     let channel = if is_initiator {
         Channel::Closed(closed_channel)
@@ -2830,14 +2832,16 @@ where
             counter_party: signed_channel.counter_party,
             temporary_channel_id: signed_channel.temporary_channel_id,
             channel_id: signed_channel.channel_id,
-            reference_id: signed_channel.reference_id
+            reference_id: signed_channel.reference_id,
+            closing_txid: settle_tx.txid()
         })
     } else {
         Channel::CounterClosed(ClosedChannel {
             counter_party: signed_channel.counter_party,
             temporary_channel_id: signed_channel.temporary_channel_id,
             channel_id: signed_channel.channel_id,
-            reference_id: signed_channel.reference_id
+            reference_id: signed_channel.reference_id,
+            closing_txid: settle_tx.txid()
         })
     };
     Ok((settle_tx, channel))

--- a/dlc-manager/src/sub_channel_manager.rs
+++ b/dlc-manager/src/sub_channel_manager.rs
@@ -3,7 +3,8 @@
 
 use std::{collections::HashMap, marker::PhantomData, ops::Deref, sync::Mutex};
 
-use bitcoin::{hashes::hex::ToHex, OutPoint, PackedLockTime, Script, Sequence, Transaction};
+use bitcoin::{hashes::hex::ToHex, OutPoint, PackedLockTime, Script, Sequence, Transaction, Txid};
+use bitcoin::hashes::Hash;
 use dlc::{channel::sub_channel::LN_GLUE_TX_WEIGHT, PartyParams};
 use dlc_messages::{
     channel::{AcceptChannel, OfferChannel},
@@ -3703,11 +3704,14 @@ where
                 "No such channel {:?}",
                 channel_id
             )))?;
+
         let closed_channel_data = ClosedChannel {
             counter_party: channel.get_counter_party_id(),
             temporary_channel_id: channel.get_temporary_id(),
             channel_id: channel.get_id(),
-            reference_id: None
+            reference_id: None,
+            // TODO(holzeis): Ignoring closing txid on dlc channels for sub channels
+            closing_txid: Txid::all_zeros()
         };
         let closed_channel = if counter_closed {
             Channel::CounterClosed(closed_channel_data)


### PR DESCRIPTION
This is a breaking change, old closed channels can't be read anymore. But given that old closed channel state don't provide any valuable information, I think this is acceptable.