### PR TITLE
Trigger `sub_channel_manager` periodic check less often

### DIFF
--- a/dlc-manager/src/sub_channel_manager.rs
+++ b/dlc-manager/src/sub_channel_manager.rs
@@ -2919,13 +2919,6 @@ where
             }
         }
 
-        if let Err(e) = self.dlc_channel_manager.periodic_check() {
-            error!(
-                "Error performing periodic check of the channel manager: {}",
-                e
-            );
-        }
-
         msgs
     }
 


### PR DESCRIPTION
Most users don't even need the `sub_channel_manager` periodic check to run. But some still do, because there are pending LN-DLC channels being closed in production.

So we still have to run this periodic check, but it's generally less critical. It included a regular `channel_manager` periodic check to make it more convenient for consumers to only have to run the `sub_channel_manager` periodic check.

We now remove it because in 10101 we now want to execute the `channel_manager` periodic check independently. It is therefore not needed here. We remove it to avoid any unforeseen problems.