### PR TITLE
Use correct input in settle claim transaction

### DIFF
--- a/dlc-manager/src/channel_updater.rs
+++ b/dlc-manager/src/channel_updater.rs
@@ -2855,7 +2855,6 @@ pub fn finalize_unilateral_close_settled_channel<S: Deref>(
     destination_address: &Address,
     fee_rate_per_vb: u64,
     signer: &S,
-    is_offer: bool,
     is_initiator: bool,
 ) -> Result<(Transaction, Channel), Error>
 where
@@ -2892,7 +2891,6 @@ where
         CET_NSEQUENCE,
         0,
         fee_rate_per_vb,
-        is_offer,
     )?;
 
     let closing_channel = SettledClosingChannel {

--- a/dlc-manager/src/manager.rs
+++ b/dlc-manager/src/manager.rs
@@ -1298,11 +1298,10 @@ where
         &self,
         signed_channel: SignedChannel,
     ) -> Result<(), Error> {
-        let (settle_tx, &is_offer, &is_initiator) = get_signed_channel_state!(
+        let (settle_tx, &is_initiator) = get_signed_channel_state!(
             signed_channel,
             SettledClosing,
             settle_transaction,
-            is_offer,
             is_initiator
         )?;
 
@@ -1312,11 +1311,9 @@ where
             >= CET_NSEQUENCE
         {
             log::info!(
-                "Settle transaction {} for channel {} has enough confirmations to spend from it. is_offer={}, is_initiator={}",
+                "Settle transaction {} for channel {} has enough confirmations to spend from it",
                 settle_tx.txid(),
                 serialize_hex(&signed_channel.channel_id),
-                is_offer,
-                is_initiator
             );
 
             let fee_rate_per_vb: u64 = {
@@ -1338,7 +1335,6 @@ where
                     &self.wallet.get_new_address()?,
                     fee_rate_per_vb,
                     &self.wallet,
-                    is_offer,
                     is_initiator,
                 )?;
 


### PR DESCRIPTION
Relying on the `is_offer` heuristic caused problems in production.