### PR TITLE
Use `ConfirmationTarget::Background` to claim settle TX outputs

### DIFF
--- a/dlc-manager/src/manager.rs
+++ b/dlc-manager/src/manager.rs
@@ -1320,7 +1320,7 @@ where
                 let fee_rate = self
                     .fee_estimator
                     .get_est_sat_per_1000_weight(
-                        ConfirmationTarget::HighPriority,
+                        ConfirmationTarget::Background,
                     );
 
                 let fee_rate = fee_rate / 250;


### PR DESCRIPTION
There is actually no protocol pressure to claim these outputs quickly, so it seems foolish to pay a possibly very high price for these claim transactions.